### PR TITLE
Split JSON files

### DIFF
--- a/run.py
+++ b/run.py
@@ -45,7 +45,7 @@ def run(path_eve, server_alias, path_cachedcalls, filter_string, language, path_
         pickle_miner]
 
     writers = [
-        JsonWriter(path_json, indent=2)]
+        JsonWriter(path_json, indent=2, group=5000)]
 
     FlowManager(miners, writers).run(filter_string=filter_string, language=language)
 

--- a/writer/json_writer.py
+++ b/writer/json_writer.py
@@ -129,7 +129,7 @@ class JsonWriter(BaseWriter):
                 if type(container_data) == dict:
                     data = dict((k, container_data[k]) for k in group if k is not None)
                 else:
-                    data = list(group)
+                    data = [k for k in group if k is not None]
                 self.__write_file(data, filepath)
 
     def __write_file(self, data, filepath):


### PR DESCRIPTION
Heyo!

While working on the translation pieces for pyfa (https://github.com/pyfa-org/Pyfa/pull/2208) was running into a file size issue with the json files that are dumped. GitHub allows up to 100MB, and the `evetypes` specifically was 114MB with all the translations.

See the issue for other details, as well as some other ideas that I had (instead of splitting files by the number of iterations, can also split by translated text, etc). But this was the easiest way to get us moving forward.

If we don't want this in the official Phobos repo, that's totally cool. Eventually I want to get the scripts in pyfa working with the changes in Phobos (`dump_data.py`), import what we need, and supply our own writer class that can do this (in case nothing better comes along). But figured I'd throw this in a PR and let you advise :)